### PR TITLE
Check for mergedData type before assigning to layerObj

### DIFF
--- a/src/map/prepareLayer.js
+++ b/src/map/prepareLayer.js
@@ -263,7 +263,9 @@ function fetchMultipleSources(mapId, layer, dispatch) {
         : mergedData = parseData(layerObj['data-parse'], (mergedData.features || mergedData));
     }
 
-    layerObj.mergedData = { ...mergedData };
+    layerObj.mergedData = Array.isArray(mergedData)
+      ? [...mergedData]
+      : { ...mergedData };
     if (layerObj.aggregate && layerObj.aggregate.filter) {
       layerObj.filterOptions = generateFilterOptions(layerObj);
     }


### PR DESCRIPTION
This PR fixes errors seen when loading aggregated layers in Rohingya