### PR TITLE
Update activeLayerId when changing primary layer

### DIFF
--- a/src/store/reducers/reducers.js
+++ b/src/store/reducers/reducers.js
@@ -247,6 +247,7 @@ export function createMapReducer(mapId) {
           return {
             ...state,
             primaryLayer: action.primaryLayer,
+            activeLayerId: action.primaryLayer,
             filter: {
               ...state.filter,
               layerId: primaryLayerHasFilter ? action.primaryLayer : false,


### PR DESCRIPTION
This updates the layerObj in Map.js and may have further implications.

For onaio/service-mapping#127 