### PR TITLE
Resolve map popup not showing when source data numerical value is of type string

### DIFF
--- a/src/map/addPopUp.js
+++ b/src/map/addPopUp.js
@@ -114,10 +114,14 @@ export default function addMousemoveEvent(mapId, mapboxGLMap, dispatch) {
             // if row matches property
             if (
               (layer.popup.join &&
-                row[layer.popup.join[0]] ===
+                // Use double equals to ensure matches when source data numbers are formatted as strings
+                // eslint-disable-next-line eqeqeq
+                row[layer.popup.join[0]] ==
                   (feature.properties && feature.properties[layer.popup.join[1]])) ||
               (!layer.popup.join &&
-                row[layer.source.join[1]] ===
+                // Use double equals to ensure matches when source data numbers are formatted as strings
+                // eslint-disable-next-line eqeqeq
+                row[layer.source.join[1]] ==
                   (feature.properties && feature.properties[layer.source.join[0]]))
             ) {
               // Add header and body to popup with data from layer

--- a/src/map/addPopUp.js
+++ b/src/map/addPopUp.js
@@ -114,12 +114,14 @@ export default function addMousemoveEvent(mapId, mapboxGLMap, dispatch) {
             // if row matches property
             if (
               (layer.popup.join &&
-                // Use double equals to ensure matches when source data numbers are formatted as strings
+                /* Use double equals to ensure matches when source data numbers are formatted as strings e.g
+                123" instead of 123 */
                 // eslint-disable-next-line eqeqeq
                 row[layer.popup.join[0]] ==
                   (feature.properties && feature.properties[layer.popup.join[1]])) ||
               (!layer.popup.join &&
-                // Use double equals to ensure matches when source data numbers are formatted as strings
+                /* Use double equals to ensure matches when source data numbers are formatted as strings e.g
+                123" instead of 123 */
                 // eslint-disable-next-line eqeqeq
                 row[layer.source.join[1]] ==
                   (feature.properties && feature.properties[layer.source.join[0]]))


### PR DESCRIPTION
Use double equals to ensure matches when source data numbers are formatted as strings